### PR TITLE
feat: Add UUID v7 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ sha2 = "0.10"
 sha1 = "0.10"
 md-5 = "0.10"
 urlencoding = "2.1.3"
-uuid = { version = "1.11.0", features = ["v1", "v3", "v4", "v5"] }
+uuid = { version = "1.11.0", features = ["v1", "v3", "v4", "v5", "v7"] }
 rust_decimal = { version = "1.38.0", features = ["macros", "maths"] }
 nom = "7.1"
 num-traits = "0.2.19"

--- a/src/tools/uuid.rs
+++ b/src/tools/uuid.rs
@@ -70,6 +70,12 @@ enum UUIDCommand {
         #[arg(short = 'c', long = "count", default_value = "1")]
         quantity: usize,
     },
+    /// Generate UUID v7 (timestamp-based, sortable)
+    V7 {
+        /// Number of UUIDs to generate
+        #[arg(short = 'c', long = "count", default_value = "1")]
+        quantity: usize,
+    },
 }
 
 impl Tool for UUIDTool {
@@ -106,6 +112,9 @@ impl Tool for UUIDTool {
                 (0..*quantity)
                     .map(|_| Uuid::new_v5(&ns_uuid, name.as_bytes()).to_string())
                     .collect()
+            }
+            UUIDCommand::V7 { quantity } => {
+                (0..*quantity).map(|_| Uuid::now_v7().to_string()).collect()
             }
         };
 


### PR DESCRIPTION
## Summary
Add support for generating UUID version 7 (timestamp-based, sortable).

UUID v7 is ideal for database keys and scenarios requiring ordered UUIDs.

## Changes
- Add `v7` feature to uuid crate dependency
- Add `v7` subcommand to uuid tool
- Implement v7 generation using `Uuid::now_v7()`

## Usage
```bash
ut uuid v7
ut uuid v7 --count 5
```

## Test Plan
- [x] Code compiles successfully
- [x] Single UUID generation works
- [x] Multiple UUID generation works with `--count` flag
- [x] UUIDs are properly formatted
- [x] Help text displays correctly