### PR TITLE
Feat/stdin piping

### DIFF
--- a/src/tools/base64.rs
+++ b/src/tools/base64.rs
@@ -17,7 +17,7 @@ pub struct Base64Tool {
 enum Base64Command {
     /// Base64 encode contents
     Encode {
-        /// Input to encode
+        /// Input to encode (use "-" for stdin)
         text: StringInput,
         /// Encode with urlsafe character set
         #[arg(long)]
@@ -25,7 +25,7 @@ enum Base64Command {
     },
     /// Base64 decode contents
     Decode {
-        /// Input to decode
+        /// Input to decode (use "-" for stdin)
         text: StringInput,
         /// Decode with urlsafe character set
         #[arg(long)]

--- a/src/tools/bcrypt.rs
+++ b/src/tools/bcrypt.rs
@@ -14,7 +14,7 @@ pub struct BcryptTool {
 enum BcryptCommand {
     /// Hash a password using bcrypt
     Hash {
-        /// Password to hash
+        /// Password to hash (use "-" for stdin)
         password: StringInput,
 
         /// Cost factor (4-31, default: 12). Higher values are more secure but slower
@@ -23,7 +23,7 @@ enum BcryptCommand {
     },
     /// Verify a password against a bcrypt hash
     Verify {
-        /// Password to verify
+        /// Password to verify (use "-" for stdin)
         password: StringInput,
 
         /// Bcrypt hash to verify against

--- a/src/tools/calc.rs
+++ b/src/tools/calc.rs
@@ -20,7 +20,7 @@ use serde_json::json;
 #[derive(Parser, Debug)]
 #[command(name = "calc", about = "Expression calculator with math functions")]
 pub struct CalcTool {
-    /// Expression to evaluate
+    /// Expression to evaluate (use "-" for stdin)
     /// Supports arithmetic, functions, constants, and multiple number formats
     expression: StringInput,
 }

--- a/src/tools/case.rs
+++ b/src/tools/case.rs
@@ -13,42 +13,42 @@ pub struct CaseTool {
 enum CaseCommand {
     /// Convert text to lowercase
     Lower {
-        /// Text to convert
+        /// Text to convert (use "-" for stdin)
         text: StringInput,
     },
     /// Convert text to UPPERCASE
     Upper {
-        /// Text to convert
+        /// Text to convert (use "-" for stdin)
         text: StringInput,
     },
     /// Convert text to camelCase
     Camel {
-        /// Text to convert
+        /// Text to convert (use "-" for stdin)
         text: StringInput,
     },
     /// Convert text to Title Case
     Title {
-        /// Text to convert
+        /// Text to convert (use "-" for stdin)
         text: StringInput,
     },
     /// Convert text to CONSTANT_CASE
     Constant {
-        /// Text to convert
+        /// Text to convert (use "-" for stdin)
         text: StringInput,
     },
     /// Convert text to Header-Case
     Header {
-        /// Text to convert
+        /// Text to convert (use "-" for stdin)
         text: StringInput,
     },
     /// Convert text to sentence case
     Sentence {
-        /// Text to convert
+        /// Text to convert (use "-" for stdin)
         text: StringInput,
     },
     /// Convert text to snake_case
     Snake {
-        /// Text to convert
+        /// Text to convert (use "-" for stdin)
         text: StringInput,
     },
 }

--- a/src/tools/color.rs
+++ b/src/tools/color.rs
@@ -16,7 +16,7 @@ pub struct ColorTool {
 enum ColorCommand {
     /// Convert colors between different formats
     Convert {
-        /// Color value in any supported format (e.g., hex, rgb, rgba, hsl, hwb, cmyk, lch, oklch)
+        /// Color value in any supported format (use "-" for stdin)
         color: StringInput,
     },
 }

--- a/src/tools/crontab.rs
+++ b/src/tools/crontab.rs
@@ -21,7 +21,7 @@ pub struct CrontabTool {
 enum CrontabCommand {
     /// Parse crontab expression and show upcoming firing times
     Schedule {
-        /// Crontab expression (e.g., "0 9 * * 1-5" for weekdays at 9 AM, or "0 0 9 * * 1-5" for extended format)
+        /// Crontab expression (use "-" for stdin)
         expression: StringInput,
 
         /// Number of upcoming firing times to show (default: 5)

--- a/src/tools/datetime.rs
+++ b/src/tools/datetime.rs
@@ -19,7 +19,7 @@ use nom::{
     about = "Parse and convert datetime to different timezones"
 )]
 pub struct DateTimeTool {
-    /// DateTime value to parse
+    /// DateTime value to parse (use "-" for stdin)
     ///
     /// Supported formats:
     /// - "now" for current time

--- a/src/tools/hash.rs
+++ b/src/tools/hash.rs
@@ -17,32 +17,32 @@ pub struct HashTool {
 enum HashCommand {
     /// Generate MD5 hash
     Md5 {
-        /// Input to hash
+        /// Input to hash (use "-" for stdin)
         input: StringInput,
     },
     /// Generate SHA-1 hash
     Sha1 {
-        /// Input to hash
+        /// Input to hash (use "-" for stdin)
         input: StringInput,
     },
     /// Generate SHA-224 hash
     Sha224 {
-        /// Input to hash
+        /// Input to hash (use "-" for stdin)
         input: StringInput,
     },
     /// Generate SHA-256 hash
     Sha256 {
-        /// Input to hash
+        /// Input to hash (use "-" for stdin)
         input: StringInput,
     },
     /// Generate SHA-384 hash
     Sha384 {
-        /// Input to hash
+        /// Input to hash (use "-" for stdin)
         input: StringInput,
     },
     /// Generate SHA-512 hash
     Sha512 {
-        /// Input to hash
+        /// Input to hash (use "-" for stdin)
         input: StringInput,
     },
 }

--- a/src/tools/qr.rs
+++ b/src/tools/qr.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 #[command(name = "qr", about = "Generate QR codes")]
 pub struct QRTool {
-    /// The text or URL to encode as QR code
+    /// The text or URL to encode as QR code (use "-" for stdin)
     text: StringInput,
 
     /// Save QR code to file (PNG format)

--- a/src/tools/url.rs
+++ b/src/tools/url.rs
@@ -14,12 +14,12 @@ pub struct UrlTool {
 enum UrlCommand {
     /// URL encode text
     Encode {
-        /// Text to URL encode
+        /// Text to URL encode (use "-" for stdin)
         text: StringInput,
     },
     /// URL decode text
     Decode {
-        /// Text to URL decode
+        /// Text to URL decode (use "-" for stdin)
         text: StringInput,
     },
 }


### PR DESCRIPTION
## Summary

Add stdin piping support across all text-input tools using `-` as the argument, enabling seamless Unix-style command composition.

This enhancement allows users to pipe data directly into `ut` commands without needing temporary files or complex workarounds. Input is preserved as-is without automatic whitespace trimming to ensure predictable behavior for sensitive operations like hashing and encoding.

## Changes

- Update 8 tools to support stdin input: `bcrypt`, `url`, `qr`, `case`, `crontab`, `calc`, `color`, `datetime`
- Leverage existing `StringInput` type from `src/args.rs` for consistent implementation
- Add comprehensive README documentation with usage examples and newline handling guidance
- Update all test cases to use `StringInput` wrapper (~165 lines of test updates)

## Features

- Consistent `-` syntax across all text-input tools
- Explicit stdin control (no auto-detection)
- Clear documentation about trailing newlines from `echo`
- Backward compatible - existing usage unchanged

## Usage

```bash
# Base64 encoding
echo -n "hello world" | ut base64 encode -

# URL encoding
printf "hello world" | ut url encode -

# Hash generation
echo -n "password" | ut hash sha256 -

# Case conversion
printf "HELLO WORLD" | ut case lower -
```

## Output Example

```bash
$ echo -n "hello world" | ut base64 encode -
aGVsbG8gd29ybGQ=

$ printf "test@example.com" | ut url encode -
test%40example.com
```

## Test Plan

- Code compiles successfully
- All existing tests pass (200+ tests updated with `StringInput` wrapper)
- Manual testing verified:
  - Piping works correctly with all updated tools
  - Whitespace preserved as expected
  - Tools work with both stdin and direct arguments