### PR TITLE
feat(case): add kebab-case conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ After setting up completions, restart your shell or source your configuration fi
 │   │   ├── constant
 │   │   ├── header
 │   │   ├── sentence
-│   │   └── snake
+│   │   ├── snake
+│   │   └── kebab
 │   ├── pretty-print (pp) - Unescape newlines and tabs
 │   └── diff        - Compare text with visual output
 ├── Development Tools
@@ -294,12 +295,13 @@ ut random --min 0 --max 1 --step 0.01 --count 10
 
 #### `case`
 Convert text between different case formats.
-- lowercase, UPPERCASE, camelCase, snake_case, Title Case, CONSTANT_CASE, Header-Case, Sentence case
+- lowercase, UPPERCASE, camelCase, snake_case, kebab-case, Title Case, CONSTANT_CASE, Header-Case, Sentence case
 
 ```bash
 ut case lower "Hello World"
 ut case camel "hello_world"
 ut case snake "HelloWorld"
+ut case kebab "HelloWorld"
 echo -n "Hello :)" | ut case lower -
 ```
 

--- a/src/tools/case.rs
+++ b/src/tools/case.rs
@@ -51,6 +51,11 @@ enum CaseCommand {
         /// Text to convert (use "-" for stdin)
         text: StringInput,
     },
+    /// Convert text to kebab-case
+    Kebab {
+        /// Text to convert (use "-" for stdin)
+        text: StringInput,
+    },
 }
 
 impl Tool for CaseTool {
@@ -68,6 +73,7 @@ impl Tool for CaseTool {
             CaseCommand::Header { text } => to_header_case(text.as_ref()),
             CaseCommand::Sentence { text } => to_sentence_case(text.as_ref()),
             CaseCommand::Snake { text } => to_snake_case(text.as_ref()),
+            CaseCommand::Kebab { text } => to_kebab_case(text.as_ref()),
         };
 
         Ok(Some(Output::JsonValue(serde_json::json!(result))))
@@ -151,6 +157,15 @@ fn to_snake_case(text: &str) -> String {
         .map(|word| word.to_lowercase())
         .collect::<Vec<_>>()
         .join("_")
+}
+
+// kebab-case
+fn to_kebab_case(text: &str) -> String {
+    split_words(text)
+        .iter()
+        .map(|word| word.to_lowercase())
+        .collect::<Vec<_>>()
+        .join("-")
 }
 
 // Splits a string into a sequence of words based on the whitespace, hyphens,
@@ -271,6 +286,15 @@ mod tests {
         assert_eq!(to_snake_case("helloWorld"), "hello_world");
         assert_eq!(to_snake_case("HELLO_WORLD"), "hello_world");
         assert_eq!(to_snake_case("hello-world"), "hello_world");
+    }
+
+    #[test]
+    fn test_kebab_case() {
+        assert_eq!(to_kebab_case("hello world"), "hello-world");
+        assert_eq!(to_kebab_case("Hello World"), "hello-world");
+        assert_eq!(to_kebab_case("helloWorld"), "hello-world");
+        assert_eq!(to_kebab_case("HELLO_WORLD"), "hello-world");
+        assert_eq!(to_kebab_case("hello-world"), "hello-world");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a `kebab` subcommand to the case tool and implement `to_kebab_case`
- document the new option in the Text Processing command tree and examples

## Testing
- cargo test case
