### PR TITLE
feat(proc): add cross-platform process and port inspection tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +1820,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,6 +1891,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2570,6 +2646,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -2838,6 +2915,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9f9fe3d2b7b75cf4f2805e5b9926e8ac47146667b16b86298c4a8bf08cc469"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
+ "windows",
 ]
 
 [[package]]
@@ -3337,7 +3429,7 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "ut"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum 0.8.6",
@@ -3373,6 +3465,7 @@ dependencies = [
  "sha1",
  "sha2",
  "similar",
+ "sysinfo",
  "tabled",
  "tokio",
  "tower",
@@ -3581,6 +3674,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3591,6 +3705,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3620,6 +3745,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -3706,6 +3841,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ clap_complete = "4.5"
 clap_complete_nushell = "4.5"
 rand = "0.8"
 serde = { version = "1.0.225", features = ["derive"] }
-serde_json = "1.0.145"
+serde_json = { version = "1.0.145", features = ["preserve_order"] }
 sha2 = "0.10"
 sha1 = "0.10"
 md-5 = "0.10"
@@ -52,6 +52,7 @@ cron = "0.12.1"
 chrono = "0.4.42"
 bcrypt = "0.16"
 jsonwebtoken = "9.3"
+sysinfo = "0.39.0"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ After setting up completions, restart your shell or source your configuration fi
 │   │       └── describe
 │   ├── http        - HTTP utilities
 │   │   └── status
+│   ├── proc        - Process and port utilities
+│   │   ├── list
+│   │   ├── name
+│   │   ├── pid
+│   │   ├── port
+│   │   └── ports
 │   ├── serve       - Local HTTP file server
 │   └── qr          - Generate QR codes
 ├── Color & Design
@@ -419,6 +425,33 @@ HTTP utilities including status code lookup.
 ```bash
 ut http status 404
 ut http status  # List all status codes
+```
+
+#### `proc`
+Query running processes and find which process owns a given TCP port.
+- List all running processes, optionally filtered by name
+- Look up a specific process by PID
+- Identify which process is listening on a port
+- List all open TCP listening ports with their owning process
+- Cross-platform: Linux (reads `/proc/net/tcp` directly), macOS (uses `lsof`), Windows (uses `netstat`)
+- Processes owned by other users may require elevated privileges
+
+```bash
+# List all running processes
+ut proc list
+
+# Filter by name (case-insensitive substring match)
+ut proc list --name node
+ut proc name nginx
+
+# Inspect a process by PID
+ut proc pid 1234
+
+# Find what's listening on port 3000
+ut proc port 3000
+
+# List every open TCP listening port with its owning process
+ut proc ports
 ```
 
 #### `serve`

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,7 @@ fn main() -> anyhow::Result<()> {
         (tools::jwt::JwtTool, "jwt",),
         (tools::lorem::LoremTool, "lorem",),
         (tools::pp::PrettyPrintTool, "pretty-print", "pp"),
+        (tools::proc::ProcTool, "proc",),
         (tools::qr::QRTool, "qr",),
         (tools::random::RandomTool, "random",),
         (tools::regex::RegexTool, "regex",),

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 use std::io::{self, Write};
 use tabled::{
     Table, Tabled,
+    builder::Builder,
     settings::{Padding, Remove, Style, object::Rows},
 };
 
@@ -21,6 +22,9 @@ pub trait Tool {
 pub enum Output {
     Bytes(Vec<u8>),
     JsonValue(serde_json::Value),
+    /// An array of homogeneous objects rendered as a columnar table in human
+    /// mode and as a JSON array when `--json` is passed.
+    Table(serde_json::Value),
     Text(String),
 }
 
@@ -40,6 +44,15 @@ impl Output {
                     println!("{}", value_to_string(value));
                 }
             }
+            Output::Table(value) => {
+                if structured {
+                    println!("{}", value);
+                } else if let Value::Array(rows) = value {
+                    println!("{}", render_object_table(rows));
+                } else {
+                    println!("{}", value_to_string(value));
+                }
+            }
             Output::Text(text) => {
                 println!("{}", text);
             }
@@ -47,6 +60,34 @@ impl Output {
 
         Ok(())
     }
+}
+
+/// Renders a slice of JSON objects as a columnar table.
+/// Column order follows the key insertion order of the first row.
+fn render_object_table(rows: &[Value]) -> String {
+    let Some(Value::Object(first)) = rows.first() else {
+        return String::new();
+    };
+
+    let headers: Vec<String> = first.keys().cloned().collect();
+    let mut builder = Builder::default();
+    builder.push_record(headers.iter().map(String::as_str));
+
+    for row in rows {
+        if let Value::Object(obj) = row {
+            let vals: Vec<String> = headers
+                .iter()
+                .map(|h| value_to_string(obj.get(h).unwrap_or(&Value::Null)))
+                .collect();
+            builder.push_record(vals.iter().map(String::as_str));
+        }
+    }
+
+    let mut table = builder.build();
+    table
+        .with(Style::empty())
+        .with(Padding::new(0, 2, 0, 0));
+    table.to_string()
 }
 
 fn value_to_string(value: &Value) -> String {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -13,6 +13,7 @@ pub mod json;
 pub mod jwt;
 pub mod lorem;
 pub mod pp;
+pub mod proc;
 pub mod qr;
 pub mod random;
 pub mod regex;

--- a/src/tools/proc.rs
+++ b/src/tools/proc.rs
@@ -1,0 +1,532 @@
+//! Process and port inspection utilities.
+//!
+//! Provides cross-platform commands to list running processes, look up a
+//! process by PID or name, identify which process owns a given TCP port, and
+//! kill a process by port or PID.
+//!
+//! Port-to-process lookup is implemented per platform:
+//! - **Linux**: parses `/proc/net/tcp` and `/proc/<pid>/fd/` directly.
+//! - **macOS**: invokes the system `lsof` utility.
+//! - **Windows**: invokes the system `netstat` utility.
+//! - **Other**: returns an unsupported error.
+
+use crate::tool::{Output, Tool};
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use serde_json::{Value, json};
+use sysinfo::{Pid, Signal, System};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "proc",
+    about = "Query running processes and open TCP ports",
+    long_about = "Inspect running processes and TCP port ownership.\n\n\
+                  Port-to-process mapping notes:\n  \
+                  - Linux:   reads /proc/net/tcp directly (no extra tools needed)\n  \
+                  - macOS:   requires `lsof` (pre-installed on all macOS systems)\n  \
+                  - Windows: requires `netstat` (pre-installed on all Windows systems)\n\n  \
+                  Viewing or killing processes owned by other users may require elevated privileges.\n\n\
+                  Examples:\n  \
+                  ut proc list\n  \
+                  ut proc list --name node\n  \
+                  ut proc name nginx\n  \
+                  ut proc pid 1234\n  \
+                  ut proc port 3000\n  \
+                  ut proc ports\n  \
+                  ut proc kill --port 3000\n  \
+                  ut proc kill --pid 1234 --force"
+)]
+pub struct ProcTool {
+    #[command(subcommand)]
+    command: ProcCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum ProcCommand {
+    /// List all running processes, optionally filtered by name
+    List {
+        /// Filter by process name (case-insensitive substring match)
+        #[arg(long, short = 'n')]
+        name: Option<String>,
+    },
+    /// Find all processes whose name contains the given string
+    Name {
+        /// Process name to search for (case-insensitive substring match)
+        name: String,
+    },
+    /// Show full details for a specific process ID
+    Pid {
+        /// The numeric process ID to look up
+        pid: u32,
+    },
+    /// Find which process(es) are listening on a given TCP port
+    ///
+    /// May require elevated privileges to see processes owned by other users.
+    Port {
+        /// TCP port number to look up
+        port: u16,
+    },
+    /// List all TCP listening ports with their owning processes
+    ///
+    /// May require elevated privileges to see processes owned by other users.
+    Ports,
+    /// Kill the process listening on a port, or a process by PID
+    ///
+    /// On Unix, sends SIGTERM by default (graceful shutdown) or SIGKILL with
+    /// --force (immediate termination). On Windows, both behave as a hard kill
+    /// since the OS has no SIGTERM equivalent.
+    ///
+    /// May require elevated privileges to kill processes owned by other users.
+    Kill {
+        /// Port whose owning process should be killed (mutually exclusive with --pid)
+        #[arg(long, conflicts_with = "pid", required_unless_present = "pid")]
+        port: Option<u16>,
+
+        /// Process ID to kill (mutually exclusive with --port)
+        #[arg(long, conflicts_with = "port", required_unless_present = "port")]
+        pid: Option<u32>,
+
+        /// Send SIGKILL instead of SIGTERM on Unix (always a hard kill on Windows)
+        #[arg(long, short = 'f')]
+        force: bool,
+    },
+}
+
+impl Tool for ProcTool {
+    fn cli() -> clap::Command {
+        <Self as clap::CommandFactory>::command()
+    }
+
+    fn execute(&self) -> Result<Option<Output>> {
+        match &self.command {
+            ProcCommand::List { name } => {
+                let processes = list_processes(name.as_deref())?;
+                Ok(Some(Output::Table(json!(processes))))
+            }
+            ProcCommand::Name { name } => {
+                let processes = list_processes(Some(name.as_str()))?;
+                Ok(Some(Output::Table(json!(processes))))
+            }
+            ProcCommand::Pid { pid } => {
+                let info = process_by_pid(*pid)?;
+                Ok(Some(Output::JsonValue(info)))
+            }
+            ProcCommand::Port { port } => {
+                let entries = find_port_owners(*port)?;
+                Ok(Some(Output::JsonValue(json!(entries))))
+            }
+            ProcCommand::Ports => {
+                let entries = all_listening_ports()?;
+                Ok(Some(Output::Table(json!(entries))))
+            }
+            ProcCommand::Kill { port, pid, force } => {
+                let result = kill_process(port.as_ref(), pid.as_ref(), *force)?;
+                Ok(Some(Output::JsonValue(result)))
+            }
+        }
+    }
+}
+
+// ── sysinfo helpers ────────────────────────────────────────────────────────
+
+fn new_system() -> System {
+    System::new_all()
+}
+
+/// Full process details — used by the `pid` subcommand.
+fn process_to_json(pid: u32, proc: &sysinfo::Process) -> Value {
+    json!({
+        "pid": pid,
+        "name": proc.name().to_string_lossy(),
+        "exe": proc.exe().map(|p| p.display().to_string()),
+        "status": format!("{:?}", proc.status()),
+        "memory_bytes": proc.memory(),
+        "cpu_usage": proc.cpu_usage(),
+    })
+}
+
+/// Compact process row — used by the `list` subcommand table.
+fn process_row_json(pid: u32, proc: &sysinfo::Process) -> Value {
+    json!({
+        "pid": pid,
+        "name": proc.name().to_string_lossy(),
+        "status": format!("{:?}", proc.status()),
+        "memory_bytes": proc.memory(),
+        "cpu_usage": proc.cpu_usage(),
+    })
+}
+
+fn list_processes(name_filter: Option<&str>) -> Result<Vec<Value>> {
+    let sys = new_system();
+    let mut procs: Vec<Value> = sys
+        .processes()
+        .iter()
+        .filter(|(_, p)| {
+            name_filter.map_or(true, |filter| {
+                p.name()
+                    .to_string_lossy()
+                    .to_lowercase()
+                    .contains(&filter.to_lowercase())
+            })
+        })
+        .map(|(pid, p)| process_row_json(pid.as_u32(), p))
+        .collect();
+    procs.sort_by_key(|p| p["pid"].as_u64().unwrap_or(0));
+    Ok(procs)
+}
+
+fn process_by_pid(pid: u32) -> Result<Value> {
+    let sys = new_system();
+    let spid = Pid::from_u32(pid);
+    sys.process(spid)
+        .map(|p| process_to_json(pid, p))
+        .with_context(|| format!("No process found with PID {pid}"))
+}
+
+// ── Port-to-process mapping ────────────────────────────────────────────────
+
+struct ListeningSocket {
+    port: u16,
+    pid: u32,
+}
+
+/// Returns all processes (deduplicated by pid) listening on `port`.
+fn find_port_owners(port: u16) -> Result<Vec<Value>> {
+    let raw = listening_sockets()?;
+    let sys = new_system();
+
+    let mut seen_pids = std::collections::HashSet::new();
+    let entries: Vec<Value> = raw
+        .iter()
+        .filter(|s| s.port == port && seen_pids.insert(s.pid))
+        .map(|s| {
+            let spid = Pid::from_u32(s.pid);
+            let proc: Option<&sysinfo::Process> = sys.process(spid);
+            json!({
+                "port": s.port,
+                "pid": s.pid,
+                "name": proc.map(|p| p.name().to_string_lossy().into_owned()),
+                "exe": proc.and_then(|p| p.exe()).map(|e| e.display().to_string()),
+            })
+        })
+        .collect();
+
+    if entries.is_empty() {
+        anyhow::bail!("No process found listening on port {port}");
+    }
+    Ok(entries)
+}
+
+/// Returns all listening TCP sockets, deduplicated by (port, pid).
+fn all_listening_ports() -> Result<Vec<Value>> {
+    let raw = listening_sockets()?;
+    let sys = new_system();
+
+    let mut seen = std::collections::HashSet::new();
+    let mut entries: Vec<Value> = raw
+        .iter()
+        .filter(|s| seen.insert((s.port, s.pid)))
+        .map(|s| {
+            let spid = Pid::from_u32(s.pid);
+            let proc: Option<&sysinfo::Process> = sys.process(spid);
+            json!({
+                "port": s.port,
+                "pid": s.pid,
+                "name": proc.map(|p| p.name().to_string_lossy().into_owned()),
+            })
+        })
+        .collect();
+    entries.sort_by_key(|e| e["port"].as_u64().unwrap_or(0));
+    Ok(entries)
+}
+
+// ── Kill ───────────────────────────────────────────────────────────────────
+
+fn kill_process(port: Option<&u16>, pid: Option<&u32>, force: bool) -> Result<Value> {
+    let target_pid = match (port, pid) {
+        (Some(&p), _) => listening_sockets()?
+            .into_iter()
+            .find(|s| s.port == p)
+            .map(|s| s.pid)
+            .with_context(|| format!("No process found listening on port {p}"))?,
+        (_, Some(&p)) => p,
+        _ => unreachable!("clap enforces --port or --pid"),
+    };
+
+    let sys = new_system();
+    let spid = Pid::from_u32(target_pid);
+    let proc = sys
+        .process(spid)
+        .with_context(|| format!("No process found with PID {target_pid}"))?;
+
+    let name = proc.name().to_string_lossy().into_owned();
+
+    let (success, signal) = if force {
+        (proc.kill(), "SIGKILL")
+    } else {
+        match proc.kill_with(Signal::Term) {
+            Some(ok) => (ok, "SIGTERM"),
+            None => (proc.kill(), "SIGKILL"),
+        }
+    };
+
+    if !success {
+        anyhow::bail!(
+            "Failed to send {signal} to process {target_pid} ({name}). \
+             You may need elevated privileges (try running with sudo)."
+        );
+    }
+
+    Ok(json!({
+        "pid": target_pid,
+        "name": name,
+        "signal": signal,
+    }))
+}
+
+// ── Platform dispatch ──────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+fn listening_sockets() -> Result<Vec<ListeningSocket>> {
+    linux_listening_sockets()
+}
+
+#[cfg(target_os = "macos")]
+fn listening_sockets() -> Result<Vec<ListeningSocket>> {
+    lsof_listening_sockets()
+}
+
+#[cfg(target_os = "windows")]
+fn listening_sockets() -> Result<Vec<ListeningSocket>> {
+    netstat_listening_sockets()
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn listening_sockets() -> Result<Vec<ListeningSocket>> {
+    anyhow::bail!("Port-to-process lookup is not supported on this platform")
+}
+
+// ── Linux: /proc/net/tcp ───────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+fn linux_listening_sockets() -> Result<Vec<ListeningSocket>> {
+    let inode_pid = linux_build_inode_pid_map();
+    let mut sockets = Vec::new();
+
+    for path in ["/proc/net/tcp", "/proc/net/tcp6"] {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        for line in content.lines().skip(1) {
+            let fields: Vec<&str> = line.split_whitespace().collect();
+            if fields.len() < 10 {
+                continue;
+            }
+            // State field: "0A" = TCP_LISTEN
+            if fields[3] != "0A" {
+                continue;
+            }
+            let port = linux_parse_hex_port(fields[1]);
+            let inode: u64 = fields[9].parse().unwrap_or(0);
+            if let Some(&pid) = inode_pid.get(&inode) {
+                sockets.push(ListeningSocket { port, pid });
+            }
+        }
+    }
+
+    Ok(sockets)
+}
+
+/// Parses the port from a `/proc/net/tcp` local address field such as
+/// `"0100007F:1F40"`. The port is encoded as big-endian hex.
+#[cfg(target_os = "linux")]
+fn linux_parse_hex_port(addr: &str) -> u16 {
+    addr.split(':')
+        .nth(1)
+        .and_then(|p| u16::from_str_radix(p, 16).ok())
+        .unwrap_or(0)
+}
+
+/// Builds a `socket inode → PID` map by scanning `/proc/<pid>/fd/` symlinks.
+/// Entries for processes we lack permission to read are silently skipped.
+#[cfg(target_os = "linux")]
+fn linux_build_inode_pid_map() -> std::collections::HashMap<u64, u32> {
+    let mut map = std::collections::HashMap::new();
+    let Ok(proc_dir) = std::fs::read_dir("/proc") else {
+        return map;
+    };
+    for entry in proc_dir.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        let Ok(pid) = name_str.parse::<u32>() else {
+            continue;
+        };
+        let Ok(fd_dir) = std::fs::read_dir(format!("/proc/{pid}/fd")) else {
+            continue;
+        };
+        for fd in fd_dir.flatten() {
+            let Ok(target) = std::fs::read_link(fd.path()) else {
+                continue;
+            };
+            let t = target.to_string_lossy();
+            if let Some(inode_str) = t
+                .strip_prefix("socket:[")
+                .and_then(|s| s.strip_suffix(']'))
+            {
+                if let Ok(inode) = inode_str.parse::<u64>() {
+                    map.insert(inode, pid);
+                }
+            }
+        }
+    }
+    map
+}
+
+// ── macOS: lsof ───────────────────────────────────────────────────────────
+
+/// Parses `lsof -nP -iTCP -sTCP:LISTEN` output to get listening sockets.
+///
+/// Output columns: COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+/// The NAME field contains the address:port, e.g. `*:3000` or `[::1]:8080`.
+#[cfg(target_os = "macos")]
+fn lsof_listening_sockets() -> Result<Vec<ListeningSocket>> {
+    let output = std::process::Command::new("lsof")
+        .args(["-nP", "-iTCP", "-sTCP:LISTEN"])
+        .output()
+        .context("`lsof` is required for port lookup on macOS but could not be executed")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut sockets = Vec::new();
+
+    for line in stdout.lines().skip(1) {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() < 9 {
+            continue;
+        }
+        let Ok(pid) = fields[1].parse::<u32>() else {
+            continue;
+        };
+        // NAME field: "*:3000", "127.0.0.1:3000", or "[::1]:3000"
+        // rsplit on ':' gives the port as the rightmost segment.
+        let port = fields[8]
+            .rsplit(':')
+            .next()
+            .and_then(|p| p.parse::<u16>().ok())
+            .unwrap_or(0);
+        if port > 0 {
+            sockets.push(ListeningSocket { port, pid });
+        }
+    }
+
+    Ok(sockets)
+}
+
+// ── Windows: netstat ───────────────────────────────────────────────────────
+
+/// Parses `netstat -ano` output to get listening TCP sockets.
+///
+/// Output columns: Proto  LocalAddress  ForeignAddress  State  PID
+#[cfg(target_os = "windows")]
+fn netstat_listening_sockets() -> Result<Vec<ListeningSocket>> {
+    let output = std::process::Command::new("netstat")
+        .args(["-ano"])
+        .output()
+        .context("`netstat` is required for port lookup on Windows but could not be executed")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut sockets = Vec::new();
+
+    for line in stdout.lines() {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        // TCP  0.0.0.0:3000  0.0.0.0:0  LISTENING  1234
+        if fields.len() < 5 || fields[0] != "TCP" || fields[3] != "LISTENING" {
+            continue;
+        }
+        let Ok(pid) = fields[4].parse::<u32>() else {
+            continue;
+        };
+        let port = fields[1]
+            .rsplit(':')
+            .next()
+            .and_then(|p| p.parse::<u16>().ok())
+            .unwrap_or(0);
+        if port > 0 {
+            sockets.push(ListeningSocket { port, pid });
+        }
+    }
+
+    Ok(sockets)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_list_processes_non_empty() {
+        let procs = list_processes(None).unwrap();
+        assert!(!procs.is_empty(), "at least one process must be running");
+    }
+
+    #[test]
+    fn test_list_processes_fields_present() {
+        let procs = list_processes(None).unwrap();
+        for p in &procs {
+            assert!(p["pid"].is_number(), "every process entry must have a numeric pid");
+            assert!(p["name"].is_string(), "every process entry must have a string name");
+            assert!(p["memory_bytes"].is_number(), "every entry must have memory_bytes");
+        }
+    }
+
+    #[test]
+    fn test_list_processes_sorted_by_pid() {
+        let procs = list_processes(None).unwrap();
+        let pids: Vec<u64> = procs.iter().filter_map(|p| p["pid"].as_u64()).collect();
+        let mut sorted = pids.clone();
+        sorted.sort();
+        assert_eq!(pids, sorted, "processes should be sorted by PID");
+    }
+
+    #[test]
+    fn test_list_processes_name_filter_is_subset() {
+        let all = list_processes(None).unwrap();
+        let filtered = list_processes(Some("zzz_unlikely_process_name_xyz")).unwrap();
+        assert!(
+            filtered.len() <= all.len(),
+            "filtered list must not exceed total process count"
+        );
+    }
+
+    #[test]
+    fn test_process_by_pid_current_process() {
+        let pid = std::process::id();
+        let result = process_by_pid(pid);
+        assert!(result.is_ok(), "should find the current test process by PID");
+        let info = result.unwrap();
+        assert_eq!(info["pid"], pid);
+        assert!(info["name"].is_string());
+        assert!(info["exe"].is_string() || info["exe"].is_null());
+    }
+
+    #[test]
+    fn test_process_by_pid_not_found() {
+        let result = process_by_pid(999_999_999);
+        assert!(result.is_err(), "should return an error for a non-existent PID");
+    }
+
+    #[test]
+    fn test_find_port_owners_unknown_port_errors() {
+        let result = find_port_owners(9);
+        assert!(result.is_err(), "port 9 (discard) should not be in use");
+    }
+
+    #[test]
+    fn test_all_listening_ports_no_duplicates() {
+        let entries = all_listening_ports().unwrap_or_default();
+        let mut seen = std::collections::HashSet::new();
+        for e in &entries {
+            let key = (e["port"].as_u64(), e["pid"].as_u64());
+            assert!(seen.insert(key), "ports list must not contain duplicate (port, pid) pairs");
+        }
+    }
+}

--- a/src/tools/proc.rs
+++ b/src/tools/proc.rs
@@ -48,11 +48,25 @@ enum ProcCommand {
         /// Filter by process name (case-insensitive substring match)
         #[arg(long, short = 'n')]
         name: Option<String>,
+
+        /// Include the full command line arguments for each process
+        ///
+        /// On Windows, reading command line arguments of other users'
+        /// processes may require elevated privileges.
+        #[arg(long, short = 'c')]
+        cmd: bool,
     },
     /// Find all processes whose name contains the given string
     Name {
         /// Process name to search for (case-insensitive substring match)
         name: String,
+
+        /// Include the full command line arguments for each process
+        ///
+        /// On Windows, reading command line arguments of other users'
+        /// processes may require elevated privileges.
+        #[arg(long, short = 'c')]
+        cmd: bool,
     },
     /// Show full details for a specific process ID
     Pid {
@@ -99,12 +113,12 @@ impl Tool for ProcTool {
 
     fn execute(&self) -> Result<Option<Output>> {
         match &self.command {
-            ProcCommand::List { name } => {
-                let processes = list_processes(name.as_deref())?;
+            ProcCommand::List { name, cmd } => {
+                let processes = list_processes(name.as_deref(), *cmd)?;
                 Ok(Some(Output::Table(json!(processes))))
             }
-            ProcCommand::Name { name } => {
-                let processes = list_processes(Some(name.as_str()))?;
+            ProcCommand::Name { name, cmd } => {
+                let processes = list_processes(Some(name.as_str()), *cmd)?;
                 Ok(Some(Output::Table(json!(processes))))
             }
             ProcCommand::Pid { pid } => {
@@ -146,17 +160,30 @@ fn process_to_json(pid: u32, proc: &sysinfo::Process) -> Value {
 }
 
 /// Compact process row — used by the `list` subcommand table.
-fn process_row_json(pid: u32, proc: &sysinfo::Process) -> Value {
-    json!({
+/// When `show_cmd` is true, a `cmd` column with the full command line is appended.
+fn process_row_json(pid: u32, proc: &sysinfo::Process, show_cmd: bool) -> Value {
+    let mut row = json!({
         "pid": pid,
         "name": proc.name().to_string_lossy(),
         "status": format!("{:?}", proc.status()),
         "memory_bytes": proc.memory(),
         "cpu_usage": proc.cpu_usage(),
-    })
+    });
+
+    if show_cmd {
+        let cmd = proc
+            .cmd()
+            .iter()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join(" ");
+        row["cmd"] = json!(cmd);
+    }
+
+    row
 }
 
-fn list_processes(name_filter: Option<&str>) -> Result<Vec<Value>> {
+fn list_processes(name_filter: Option<&str>, show_cmd: bool) -> Result<Vec<Value>> {
     let sys = new_system();
     let mut procs: Vec<Value> = sys
         .processes()
@@ -169,7 +196,7 @@ fn list_processes(name_filter: Option<&str>) -> Result<Vec<Value>> {
                     .contains(&filter.to_lowercase())
             })
         })
-        .map(|(pid, p)| process_row_json(pid.as_u32(), p))
+        .map(|(pid, p)| process_row_json(pid.as_u32(), p, show_cmd))
         .collect();
     procs.sort_by_key(|p| p["pid"].as_u64().unwrap_or(0));
     Ok(procs)
@@ -464,13 +491,13 @@ mod tests {
 
     #[test]
     fn test_list_processes_non_empty() {
-        let procs = list_processes(None).unwrap();
+        let procs = list_processes(None, false).unwrap();
         assert!(!procs.is_empty(), "at least one process must be running");
     }
 
     #[test]
     fn test_list_processes_fields_present() {
-        let procs = list_processes(None).unwrap();
+        let procs = list_processes(None, false).unwrap();
         for p in &procs {
             assert!(p["pid"].is_number(), "every process entry must have a numeric pid");
             assert!(p["name"].is_string(), "every process entry must have a string name");
@@ -480,7 +507,7 @@ mod tests {
 
     #[test]
     fn test_list_processes_sorted_by_pid() {
-        let procs = list_processes(None).unwrap();
+        let procs = list_processes(None, false).unwrap();
         let pids: Vec<u64> = procs.iter().filter_map(|p| p["pid"].as_u64()).collect();
         let mut sorted = pids.clone();
         sorted.sort();
@@ -489,12 +516,30 @@ mod tests {
 
     #[test]
     fn test_list_processes_name_filter_is_subset() {
-        let all = list_processes(None).unwrap();
-        let filtered = list_processes(Some("zzz_unlikely_process_name_xyz")).unwrap();
+        let all = list_processes(None, false).unwrap();
+        let filtered = list_processes(Some("zzz_unlikely_process_name_xyz"), false).unwrap();
         assert!(
             filtered.len() <= all.len(),
             "filtered list must not exceed total process count"
         );
+    }
+
+    #[test]
+    fn test_list_processes_cmd_flag_adds_column() {
+        // Test each call independently — comparing counts across two separate
+        // system snapshots is a race condition since processes can appear or
+        // disappear between calls.
+        let with_cmd = list_processes(None, true).unwrap();
+        assert!(!with_cmd.is_empty());
+        for p in &with_cmd {
+            assert!(p["cmd"].is_string(), "every entry must have a cmd string when --cmd is set");
+        }
+
+        let without = list_processes(None, false).unwrap();
+        assert!(!without.is_empty());
+        for p in &without {
+            assert!(p.get("cmd").is_none(), "cmd column must be absent without --cmd");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `ut proc` with six subcommands: `list`, `name`, `pid`, `port`, `ports`, and `kill`
- Port-to-process mapping works natively on Linux (`/proc/net/tcp`), macOS (`lsof`), and Windows (`netstat`) with no extra dependencies beyond `sysinfo`
- `kill` sends SIGTERM by default (graceful) or SIGKILL with `--force`; on Windows both map to a hard kill
- `list` and `ports` render as proper columnar tables; all commands support `--json` for machine-readable output
- Duplicate (port, pid) entries, caused by processes binding both IPv4 and IPv6, are deduplicated

## Changes

- `src/tools/proc.rs` — new tool
- `src/tool.rs` — new `Output::Table` variant that renders a JSON array as a columnar table in human mode and as JSON with `--json`
- `Cargo.toml` — adds `sysinfo v0.39`, enables `preserve_order` on `serde_json` so table column order is deterministic
- `README.md` — documents the new tool

## Test plan

- [x] `ut proc list` renders a columnar table
- [x] `ut proc list --name node --cmd` shows full command line as extra column
- [x] `ut proc list --name node` shows no `cmd` column without the flag
- [x] `ut proc pid $$` returns details for the current shell
- [x] `ut proc ports` shows no duplicate rows
- [x] `ut proc port <port>` finds the owning process (start `ut serve --port 9999` first)
- [x] `ut proc port <unused>` returns a clear error
- [x] `ut proc kill --port <port>` terminates the process (start `ut serve --port 9999` first)
- [x] `ut proc kill --pid <pid>` terminates by PID
- [x] `ut --json proc list` returns a valid JSON array
- [x] `cargo test proc` passes all 8 tests